### PR TITLE
feat: adds submit job request model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     'pydantic>=2.0',
     'pydantic-settings>=2.0',
     'aind-data-schema-models==0.1.1',
-    'aind-slurm-rest==0.1.0'
+    'aind-slurm-rest==0.1.0',
+    'email-validator'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #8 

- Adds model that can be used to submit a job request to the backend
- Adds enum class of email notification types
- Adds email-validator to dependency list
- Removes a regex pattern not being used here