### PR TITLE
feat: adds input data mount

### DIFF
--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -146,6 +146,11 @@ class BasicUploadJobConfigs(BaseSettings):
     project_name: str = Field(
         ..., description="Name of project", title="Project Name"
     )
+    input_data_mount: Optional[str] = Field(
+        default=None,
+        description="Input mount if user defines process_capsule_id",
+        title="Input Data Mount",
+    )
     process_capsule_id: Optional[str] = Field(
         None,
         description="Use custom codeocean capsule or pipeline id",


### PR DESCRIPTION
Closes #5 

- Adds Optional Input Data Mount
- We'll need to update the transfer service to use this field once it's released