### PR TITLE
Implement `TriggerConfigModel`

### DIFF
--- a/src/aind_data_transfer_models/trigger.py
+++ b/src/aind_data_transfer_models/trigger.py
@@ -6,7 +6,7 @@ from typing_extensions import Self
 
 from aind_data_schema_models.modalities import Modality
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ValidJobType(str, Enum):
@@ -25,76 +25,68 @@ class ValidJobType(str, Enum):
 class TriggerConfigModel(BaseModel):
     """Config to be parsed by the AIND Trigger Capsule."""
 
-    job_type: ValidJobType = (
-        Field(
-            description="The type of job to be triggered.",
-        ),
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    job_type: ValidJobType = Field(
+        description="The type of job to be triggered.",
     )
-    bucket: Optional[str] = (
-        Field(
-            description="The bucket where the data is stored.",
-            default=None,
-        ),
+    bucket: Optional[str] = Field(
+        description="The bucket where the data is stored.",
+        default=None,
     )
-    prefix: Optional[str] = (
-        Field(
-            description="The prefix where the data is stored.",
-            default=None,
-        ),
+    prefix: Optional[str] = Field(
+        description="The prefix where the data is stored.",
+        default=None,
     )
-    asset_name: Optional[str] = (
-        Field(
-            description="The name of the asset.",
-            default=None,
-        ),
+    asset_name: Optional[str] = Field(
+        description="The name of the asset.",
+        default=None,
     )
-    mount: Optional[str] = (
-        Field(
-            description="The mount point for the data.",
-            default=None,
-        ),
+
+    mount: Optional[str] = Field(
+        description="The mount point for the data.",
+        default=None,
     )
-    input_data_asset_id: Optional[Union[str, List[str]]] = (
-        Field(
-            description=(
-                "The ID of the input data asset. To attach multiple "
-                "input data assets, use semicolon as a delimiter."
-            ),
-            default=None,
+    input_data_asset_id: Optional[Union[str, List[str]]] = Field(
+        description=(
+            "The ID of the input data asset. To attach multiple "
+            "input data assets, use semicolon as a delimiter."
         ),
+        default=None,
     )
-    input_data_mount: Optional[Union[str, List[str]]] = (
-        Field(
-            description=(
-                "The mount point for the input data. If None, the input data "
-                "mount will be the same as the data asset name. For multiple "
-                "input data assets, use semicolon as a delimiter to specify "
-                "the mount path for each input data asset."
-            ),
-            default=None,
+
+    input_data_mount: Optional[Union[str, List[str]]] = Field(
+        description=(
+            "The mount point for the input data. If None, the input data "
+            "mount will be the same as the data asset name. For multiple "
+            "input data assets, use semicolon as a delimiter to specify "
+            "the mount path for each input data asset."
         ),
+        default=None,
     )
-    process_capsule_id: Optional[str] = (
-        Field(
-            description=(
-                "The ID of the process capsule. Ignored if job type is "
-                "run_generic_pipeline."
-            ),
-            default=None,
+
+    process_capsule_id: Optional[str] = Field(
+        description=(
+            "The ID of the process capsule. Ignored if job type is "
+            "run_generic_pipeline."
         ),
+        default=None,
     )
+
     capsule_version: Optional[str] = (
         Field(
             description="The version of the capsule.",
             default=None,
         ),
     )
+
     results_suffix: Optional[str] = (
         Field(
             description="The suffix to be added to the results.",
             default="processed",
         ),
     )
+
     input_data_asset_name: Optional[str] = Field(
         description=(
             "The name to use as stem for the captured asset. It is required "
@@ -126,7 +118,8 @@ class TriggerConfigModel(BaseModel):
     )
 
     @model_validator(mode="after")
-    def validate_trigger_config(self) -> Self: # noqa
+    def validate_trigger_config(self) -> Self:  # noqa
+        """Validate the trigger config."""
         # registration
         if self.bucket is not None and self.prefix is not None:
             if self.input_data_asset_id is not None:
@@ -147,26 +140,31 @@ class TriggerConfigModel(BaseModel):
             if self.process_capsule_id is None:
                 self.process_capsule_id = self.capsule_id
 
-        # input data asset ids
+        # input data asset ids, mounts, and names
         if self.input_data_asset_id is not None:
             if isinstance(self.input_data_asset_id, str):
                 self.input_data_asset_id = self.input_data_asset_id.split(";")
             if self.input_data_mount is not None:
                 self.input_data_mount = self.input_data_mount.split(";")
-                if isinstance(self.input_data_asset_id, list):
-                    if not isinstance(self.input_data_mount, list):
-                        raise ValueError(
-                            "input_data_mount should be a list if "
-                            "input_data_asset_id is a list."
-                        )
-                    if len(self.input_data_asset_id) != len(
-                        self.input_data_mount
-                    ):
-                        raise ValueError(
-                            "input_data_asset_id and input_data_mount should "
-                            "have the same length when multiple input data "
-                            "assets are attached."
-                        )
+            if isinstance(self.input_data_asset_id, list):
+                if not isinstance(self.input_data_mount, list):
+                    raise ValueError(
+                        "input_data_mount should be a list if "
+                        "input_data_asset_id is a list."
+                    )
+                if len(self.input_data_asset_id) != len(
+                    self.input_data_mount
+                ):
+                    raise ValueError(
+                        "input_data_asset_id and input_data_mount should "
+                        "have the same length when multiple input data "
+                        "assets are attached."
+                    )
+                if self.input_data_asset_name is None:
+                    raise ValueError(
+                        "input_data_asset_name is required when multiple "
+                        "input data assets are attached."
+                    )
 
         # generic pipeline
         if self.job_type == ValidJobType.RUN_GENERIC_PIPELINE:

--- a/src/aind_data_transfer_models/trigger.py
+++ b/src/aind_data_transfer_models/trigger.py
@@ -1,0 +1,178 @@
+"""Models for aind-trigger-capsule"""
+
+from enum import Enum
+from typing import List, Optional, Union
+from typing_extensions import Self
+
+from aind_data_schema_models.modalities import Modality
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class ValidJobType(str, Enum):
+    """Valid job types for the AIND Trigger Capsule."""
+
+    ECEPHYS = "ecephys"
+    ECEPHYS_OPTO = "ecephys_opto"
+    SINGLEPLANE_OPHYS = "singleplane_ophys"
+    MULTIPLANE_OPHYS = "multiplane_ophys"
+    SMARTSPIM = "smartspim"
+    RUN_GENERIC_PIPELINE = "run_generic_pipeline"
+    REGISTER_DATA = "register_data"
+    TEST = "test"
+
+
+class TriggerConfigModel(BaseModel):
+    """Config to be parsed by the AIND Trigger Capsule."""
+
+    job_type: ValidJobType = (
+        Field(
+            description="The type of job to be triggered.",
+        ),
+    )
+    bucket: Optional[str] = (
+        Field(
+            description="The bucket where the data is stored.",
+            default=None,
+        ),
+    )
+    prefix: Optional[str] = (
+        Field(
+            description="The prefix where the data is stored.",
+            default=None,
+        ),
+    )
+    asset_name: Optional[str] = (
+        Field(
+            description="The name of the asset.",
+            default=None,
+        ),
+    )
+    mount: Optional[str] = (
+        Field(
+            description="The mount point for the data.",
+            default=None,
+        ),
+    )
+    input_data_asset_id: Optional[Union[str, List[str]]] = (
+        Field(
+            description=(
+                "The ID of the input data asset. To attach multiple "
+                "input data assets, use semicolon as a delimiter."
+            ),
+            default=None,
+        ),
+    )
+    input_data_mount: Optional[Union[str, List[str]]] = (
+        Field(
+            description=(
+                "The mount point for the input data. If None, the input data "
+                "mount will be the same as the data asset name. For multiple "
+                "input data assets, use semicolon as a delimiter to specify "
+                "the mount path for each input data asset."
+            ),
+            default=None,
+        ),
+    )
+    process_capsule_id: Optional[str] = (
+        Field(
+            description=(
+                "The ID of the process capsule. Ignored if job type is "
+                "run_generic_pipeline."
+            ),
+            default=None,
+        ),
+    )
+    capsule_version: Optional[str] = (
+        Field(
+            description="The version of the capsule.",
+            default=None,
+        ),
+    )
+    results_suffix: Optional[str] = (
+        Field(
+            description="The suffix to be added to the results.",
+            default="processed",
+        ),
+    )
+    input_data_asset_name: Optional[str] = Field(
+        description=(
+            "The name to use as stem for the captured asset. It is required "
+            "when multiple input data assets are attached."
+        ),
+        default=None,
+    )
+    # From legacy aind data transfer service
+    aind_data_transfer_version: Optional[str] = Field(
+        description="The version of the AIND Data Transfer Capsule.",
+        default=None,
+    )
+    modalities: Optional[List[Modality]] = Field(
+        description=("(deprecated - use 'job_type')."),
+        default=None,
+    )
+    capsule_id: Optional[str] = Field(
+        description=(
+            "(deprecated - use 'process_capsule_id'). "
+            "The ID of the process capsule"
+        ),
+        default=None,
+    )
+    input_data_point: Optional[str] = Field(
+        description=(
+            "(deprecated - use 'input_data_mount'). " "The input data point."
+        ),
+        default=None,
+    )
+
+    @model_validator(mode="after")
+    def validate_trigger_config(self) -> Self: # noqa
+        # registration
+        if self.bucket is not None and self.prefix is not None:
+            if self.input_data_asset_id is not None:
+                raise ValueError(
+                    "If bucket and prefix are provided, input_data_asset_id "
+                    "should not be provided."
+                )
+            if self.asset_name is None:
+                self.asset_name = self.prefix
+            if self.mount is None:
+                self.mount = self.prefix
+
+        # legacy aind data transfer service
+        if self.input_data_point is not None:
+            if self.input_data_mount is None:
+                self.input_data_mount = self.input_data_point
+        if self.capsule_id is not None:
+            if self.process_capsule_id is None:
+                self.process_capsule_id = self.capsule_id
+
+        # input data asset ids
+        if self.input_data_asset_id is not None:
+            if isinstance(self.input_data_asset_id, str):
+                self.input_data_asset_id = self.input_data_asset_id.split(";")
+            if self.input_data_mount is not None:
+                self.input_data_mount = self.input_data_mount.split(";")
+                if isinstance(self.input_data_asset_id, list):
+                    if not isinstance(self.input_data_mount, list):
+                        raise ValueError(
+                            "input_data_mount should be a list if "
+                            "input_data_asset_id is a list."
+                        )
+                    if len(self.input_data_asset_id) != len(
+                        self.input_data_mount
+                    ):
+                        raise ValueError(
+                            "input_data_asset_id and input_data_mount should "
+                            "have the same length when multiple input data "
+                            "assets are attached."
+                        )
+
+        # generic pipeline
+        if self.job_type == ValidJobType.RUN_GENERIC_PIPELINE:
+            if self.process_capsule_id is None:
+                raise ValueError(
+                    "process_capsule_id is required for job type "
+                    "run_generic_pipeline."
+                )
+        return self

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -309,9 +309,10 @@ class TestSubmitJobRequest(unittest.TestCase):
                 user_email="some user",
                 upload_jobs=[BasicUploadJobConfigs(**upload_job_configs)],
             )
+        # email_validator changed error message across versions. We can just
+        # do a quick check that the error message at least contains this part.
         expected_error_message = (
             "value is not a valid email address: "
-            "An email address must have an @-sign."
         )
         actual_error_message = json.loads(e.exception.json())[0]["msg"]
         # Check only 1 validation error is raised

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -310,8 +310,8 @@ class TestSubmitJobRequest(unittest.TestCase):
                 upload_jobs=[BasicUploadJobConfigs(**upload_job_configs)],
             )
         expected_error_message = (
-            "value is not a valid email address:"
-            " The email address is not valid. It must have exactly one @-sign."
+            "value is not a valid email address: "
+            "An email address must have an @-sign."
         )
         actual_error_message = json.loads(e.exception.json())[0]["msg"]
         # Check only 1 validation error is raised

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -8,7 +8,7 @@ from aind_data_transfer_models.trigger import TriggerConfigModel
 class TestTriggerConfigModel(unittest.TestCase):
     """Tests TestTriggerConfigModel class"""
 
-    def test_ecephys_upload_and_run(self):
+    def test_upload_and_run(self):
         """Test default_output_folder_name property"""
         config = TriggerConfigModel(
             job_type="ecephys",
@@ -28,6 +28,21 @@ class TestTriggerConfigModel(unittest.TestCase):
         self.assertEqual(config.prefix, "ecephys_0000")
         self.assertEqual(config.asset_name, "ecephys_0000")
         self.assertEqual(config.mount, "ecephys_0000")
+
+        # passing upload info and input data asset id should fail
+        with self.assertRaises(ValueError):
+            config = TriggerConfigModel(
+                job_type="ecephys",
+                bucket="my-bucket",
+                prefix="ecephys_0000",
+                asset_name=None,
+                mount=None,
+                input_data_asset_id="0101",
+                input_data_mount=None,
+                process_capsule_id=None,
+                capsule_version=None,
+                results_suffix="processed",
+            )
 
     def test_multiple_assets(self):
         """Test default behavior with multiple assets"""

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,10 +1,97 @@
-"""Module to test trugger"""
+"""Module to test trigger"""
 
 import unittest
 
+from aind_data_transfer_models.trigger import TriggerConfigModel
+
 
 class TestTriggerConfigModel(unittest.TestCase):
-    """Tests ModalityConfigs class"""
+    """Tests TestTriggerConfigModel class"""
 
-    # TODO
-    pass
+    def test_ecephys_upload_and_run(self):
+        """Test default_output_folder_name property"""
+        config = TriggerConfigModel(
+            job_type="ecephys",
+            bucket="my-bucket",
+            prefix="ecephys_0000",
+            asset_name=None,
+            mount=None,
+            input_data_asset_id=None,
+            input_data_mount=None,
+            process_capsule_id=None,
+            capsule_version=None,
+            results_suffix="processed",
+            input_data_asset_name=None,
+        )
+        self.assertEqual(config.job_type, "ecephys")
+        self.assertEqual(config.bucket, "my-bucket")
+        self.assertEqual(config.prefix, "ecephys_0000")
+        self.assertEqual(config.asset_name, "ecephys_0000")
+        self.assertEqual(config.mount, "ecephys_0000")
+
+    def test_multiple_assets(self):
+        """Test default behavior with multiple assets"""
+        config = TriggerConfigModel(
+            job_type="ecephys",
+            input_data_asset_id="0000;0001",
+            input_data_mount="mount1;mount2",
+            input_data_asset_name="ecephys_session",
+        )
+        self.assertEqual(config.input_data_asset_id, ["0000", "0001"])
+        self.assertEqual(config.input_data_mount, ["mount1", "mount2"])
+
+        # passing multiple assets with only no mount points
+        with self.assertRaises(ValueError):
+            config = TriggerConfigModel(
+                job_type="ecephys",
+                input_data_asset_id="0000;0001",
+                input_data_mount=None,
+                input_data_asset_name="ecephys_session",
+            )
+
+        # passing multiple assets with only no input_data_asset_name
+        with self.assertRaises(ValueError):
+            config = TriggerConfigModel(
+                job_type="ecephys",
+                input_data_asset_id="0000;0001",
+                input_data_mount="mount1;mount2",
+            )
+
+        # passing multiple assets with unmatched mount points
+        with self.assertRaises(ValueError):
+            config = TriggerConfigModel(
+                job_type="ecephys",
+                input_data_asset_id="0000;0001",
+                input_data_mount="mount1",
+                input_data_asset_name="ecephys_session",
+            )
+
+    def test_run_generic_pipeline(self):
+        """Test run_generic_pipeline"""
+        config = TriggerConfigModel(
+            job_type="run_generic_pipeline",
+            process_capsule_id="0000",
+            capsule_version="1.0",
+        )
+        self.assertEqual(config.job_type, "run_generic_pipeline")
+        self.assertEqual(config.process_capsule_id, "0000")
+        self.assertEqual(config.capsule_version, "1.0")
+
+        with self.assertRaises(ValueError):
+            config = TriggerConfigModel(
+                job_type="run_generic_pipeline",
+                process_capsule_id=None,
+                capsule_version="1.0",
+            )
+
+    def test_legacy_fields(self):
+        """Test legacy fields"""
+        config = TriggerConfigModel(
+            job_type="ecephys",
+            input_data_point="0000",
+            input_data_mount=None,
+            capsule_id="0101",
+            process_capsule_id=None,
+        )
+        assert config.input_data_mount == "0000"
+        assert config.process_capsule_id == "0101"

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,0 +1,10 @@
+"""Module to test trugger"""
+
+import unittest
+
+
+class TestTriggerConfigModel(unittest.TestCase):
+    """Tests ModalityConfigs class"""
+
+    # TODO
+    pass


### PR DESCRIPTION
@dyf @jtyoung84 sorry this took a while on my side.

Implemented the `TriggerConfigModel` that we can use to unify calls to the aind-trigger-capsule. 

Note that the model accepts and parses strings with semicolon separation to attach multiple data assets and mount points. See after validation.

Let me know what you think!