### PR TITLE
Feat: Adds Optional Field for MetadataConfigs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'aind-slurm-rest==0.1.0',
     'aind-data-schema-models>=0.1.7',
     'email-validator',
-    'aind-metadata-mapper>=0.14.0'
+    'aind-metadata-mapper==0.14.0'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     'pydantic>=2.0',
     'pydantic-settings>=2.0',
     'aind-slurm-rest==0.1.0',
-    'aind-data-schema-models>==0.1.7',
+    'aind-data-schema-models>=0.1.7',
     'email-validator',
     'aind-metadata-mapper @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     'pydantic>=2.0',
     'pydantic-settings>=2.0',
     'aind-slurm-rest==0.1.0',
-    'aind-data-schema-models>=0.3.0',
+    'aind-data-schema-models>==0.1.7',
     'email-validator',
     'aind-metadata-mapper @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ dependencies = [
     'pydantic>=2.0',
     'pydantic-settings>=2.0',
     'aind-slurm-rest==0.1.0',
-    'aind-data-schema-models==0.1.7',
+    'aind-data-schema-models>=0.1.7',
     'email-validator',
-    'aind-metadata-mapper'
+    'aind-metadata-mapper @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     'pydantic-settings>=2.0',
     'aind-slurm-rest==0.1.0',
     'aind-data-schema-models>=0.1.1',
+    'aind-metadata-mapper<=0.14.0',
     'email-validator'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'aind-slurm-rest==0.1.0',
     'aind-data-schema-models>=0.1.7',
     'email-validator',
-    'aind-metadata-mapper @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
+    'aind-metadata-mapper>=0.14.0'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = [
     'pydantic-settings>=2.0',
     'aind-slurm-rest==0.1.0',
     'aind-data-schema-models>=0.1.1',
-    'aind-metadata-mapper<=0.14.0',
-    'email-validator'
+    'email-validator',
+    'aind-metadata-mapper[all] @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'aind-slurm-rest==0.1.0',
     'aind-data-schema-models>=0.1.1',
     'email-validator',
-    'aind-metadata-mapper[all] @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
+    'aind-metadata-mapper @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'pydantic==2.6.4',
-    'pydantic-settings==2.2.1',
+    'pydantic>=2.0',
+    'pydantic-settings>=2.0',
     'aind-slurm-rest==0.1.0',
-    'aind-data-schema-models==0.1.7',
-    'email-validator==2.2.0',
+    'aind-data-schema-models>=0.1.7',
+    'email-validator',
     'aind-metadata-mapper @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,12 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'pydantic>=2.0',
-    'pydantic-settings>=2.0',
+    'pydantic==2.6.4',
+    'pydantic-settings==2.2.1',
     'aind-slurm-rest==0.1.0',
-    'aind-data-schema-models>=0.1.7',
-    'email-validator'
+    'aind-data-schema-models==0.1.7',
+    'email-validator==2.2.0',
+    'aind-metadata-mapper @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ dependencies = [
     'pydantic>=2.0',
     'pydantic-settings>=2.0',
     'aind-slurm-rest==0.1.0',
-    'aind-data-schema-models>=0.1.7',
+    'aind-data-schema-models==0.1.7',
     'email-validator',
-    'aind-metadata-mapper==0.14.0'
+    'aind-metadata-mapper'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ dependencies = [
     'pydantic-settings>=2.0',
     'aind-slurm-rest==0.1.0',
     'aind-data-schema-models>=0.1.7',
-    'email-validator',
-    'aind-metadata-mapper @ git+https://github.com/AllenNeuralDynamics/aind-metadata-mapper@dev'
+    'email-validator'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -10,12 +10,10 @@ from aind_data_schema_models.data_name_patterns import build_data_name
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
 from aind_metadata_mapper.models import (
-    JobSettings as GatherMetadataJobSettings,
-)
-from aind_metadata_mapper.models import (
     ProceduresSettings,
     RawDataDescriptionSettings,
     SubjectSettings,
+    JobSettings as GatherMetadataJobSettings,
 )
 from aind_slurm_rest import V0036JobProperties
 from pydantic import (

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -9,6 +9,14 @@ from typing import Any, ClassVar, List, Optional, Set, Union
 from aind_data_schema_models.data_name_patterns import build_data_name
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
+from aind_metadata_mapper.models import (
+    JobSettings as GatherMetadataJobSettings,
+)
+from aind_metadata_mapper.models import (
+    ProceduresSettings,
+    RawDataDescriptionSettings,
+    SubjectSettings,
+)
 from aind_slurm_rest import V0036JobProperties
 from pydantic import (
     ConfigDict,
@@ -20,12 +28,6 @@ from pydantic import (
     model_validator,
 )
 from pydantic_settings import BaseSettings
-from aind_metadata_mapper.models import (
-    SubjectSettings,
-    ProceduresSettings,
-    RawDataDescriptionSettings,
-    JobSettings as GatherMetadataJobSettings,
-)
 
 
 class EmailNotificationType(str, Enum):

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -20,7 +20,10 @@ from pydantic import (
     model_validator,
 )
 from pydantic_settings import BaseSettings
-from aind_metadata_mapper.gather_metadata import JobSettings as GatherMetadataJobSettings
+from aind_metadata_mapper.gather_metadata import (
+    JobSettings as GatherMetadataJobSettings,
+)
+
 
 class EmailNotificationType(str, Enum):
     """Types of email notifications a user can select"""
@@ -78,7 +81,6 @@ class ModalityConfigs(BaseSettings):
         ),
         title="Slurm Settings",
     )
-
 
     @computed_field
     def output_folder_name(self) -> str:
@@ -272,19 +274,59 @@ class BasicUploadJobConfigs(BaseSettings):
             return datetime_val
 
     @field_validator("metadata_configs", mode="after")
-    def fill_in_metadata_configs(cls, input_metadata_configs:GatherMetadataJobSettings):
+    def fill_in_metadata_configs(
+        cls, input_metadata_configs: GatherMetadataJobSettings
+    ):
         """Fills in settings for gather metadata job"""
         if input_metadata_configs:
-            if getattr(input_metadata_configs, "metadata_dir") is None:
+            if not getattr(input_metadata_configs, "metadata_dir", None):
                 input_metadata_configs.metadata_dir = cls.metadata_dir
-            if getattr(input_metadata_configs, "directory_to_write_to") is None:
+            if not getattr(
+                input_metadata_configs, "directory_to_write_to", None
+            ):
                 input_metadata_configs.directory_to_write_to = "stage"
-            if getattr(input_metadata_configs, "subject_settings") and getattr(input_metadata_configs.subject_settings.subject_id) is None:
-                input_metadata_configs.subject_settings.subject_id = cls.subject_id
-            if getattr(input_metadata_configs, "acquisition_settings") and getattr(input_metadata_configs.acquisition_settings.job_settings.subject_id) is None:
-                input_metadata_configs.acquisition_settings.job_settings.subject_id = cls.subject_id
-            if getattr(input_metadata_configs, "procedures_settings") and getattr(input_metadata_configs.procedures_settings.subject_id) is None:
-                input_metadata_configs.procedures_settings.subject_id = cls.subject_id
+            if getattr(
+                input_metadata_configs, "subject_settings", None
+            ) and not getattr(
+                input_metadata_configs.subject_settings, "subject_id", None
+            ):
+                input_metadata_configs.subject_settings.subject_id = (
+                    cls.subject_id
+                )
+            if (
+                getattr(input_metadata_configs, "acquisition_settings", None)
+                and getattr(
+                    input_metadata_configs.acquisition_settings,
+                    "job_settings",
+                    None,
+                )
+                and not getattr(
+                    input_metadata_configs.acquisition_settings.job_settings,
+                    "subject_id",
+                    None,
+                )
+            ):
+                input_metadata_configs.acquisition_settings.job_settings.subject_id = (
+                    cls.subject_id
+                )
+            if getattr(
+                input_metadata_configs, "procedures_settings", None
+            ) and not getattr(
+                input_metadata_configs.procedures_settings, "subject_id", None
+            ):
+                input_metadata_configs.procedures_settings.subject_id = (
+                    cls.subject_id
+                )
+            if getattr(
+                input_metadata_configs, "session_settings", None
+            ) and not getattr(
+                input_metadata_configs.session_settings, "subject_id", None
+            ):
+                input_metadata_configs.session_settings.subject_id = (
+                    cls.subject_id
+                )
+        return input_metadata_configs
+
 
 class SubmitJobRequest(BaseSettings):
     """Main request that will be sent to the backend. Bundles jobs into a list

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -53,7 +53,7 @@ class ModalityConfigs(BaseSettings):
     # added to the Modality class
     _MODALITY_MAP: ClassVar = {
         m().abbreviation.upper().replace("-", "_"): m().abbreviation
-        for m in Modality.ALL
+        for m in Modality._ALL
     }
 
     modality: Modality.ONE_OF = Field(

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -130,7 +130,7 @@ class BasicUploadJobConfigs(BaseSettings):
     # Need some way to extract abbreviations. Maybe a public method can be
     # added to the Platform class
     _PLATFORM_MAP: ClassVar = {
-        p().abbreviation.upper(): p().abbreviation for p in Platform.ALL
+        p().abbreviation.upper(): p().abbreviation for p in Platform._ALL
     }
     _DATETIME_PATTERN1: ClassVar = re.compile(
         r"^\d{4}-\d{2}-\d{2}[ |T]\d{2}:\d{2}:\d{2}$"

--- a/src/aind_data_transfer_models/trigger.py
+++ b/src/aind_data_transfer_models/trigger.py
@@ -152,9 +152,7 @@ class TriggerConfigModel(BaseModel):
                         "input_data_mount should be a list if "
                         "input_data_asset_id is a list."
                     )
-                if len(self.input_data_asset_id) != len(
-                    self.input_data_mount
-                ):
+                if len(self.input_data_asset_id) != len(self.input_data_mount):
                     raise ValueError(
                         "input_data_asset_id and input_data_mount should "
                         "have the same length when multiple input data "

--- a/src/aind_data_transfer_models/trigger.py
+++ b/src/aind_data_transfer_models/trigger.py
@@ -2,11 +2,10 @@
 
 from enum import Enum
 from typing import List, Optional, Union
-from typing_extensions import Self
 
 from aind_data_schema_models.modalities import Modality
-
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing_extensions import Self
 
 
 class ValidJobType(str, Enum):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -311,9 +311,7 @@ class TestSubmitJobRequest(unittest.TestCase):
             )
         # email_validator changed error message across versions. We can just
         # do a quick check that the error message at least contains this part.
-        expected_error_message = (
-            "value is not a valid email address: "
-        )
+        expected_error_message = "value is not a valid email address: "
         actual_error_message = json.loads(e.exception.json())[0]["msg"]
         # Check only 1 validation error is raised
         self.assertEqual(1, len(json.loads(e.exception.json())))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,11 @@ from pathlib import PurePosixPath
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
+from aind_metadata_mapper.models import (
+    ProceduresSettings,
+    SubjectSettings,
+    JobSettings as GatherMetadataJobSettings,
+)
 from aind_slurm_rest import V0036JobProperties
 from pydantic import ValidationError
 
@@ -17,13 +22,7 @@ from aind_data_transfer_models.core import (
     ModalityConfigs,
     SubmitJobRequest,
 )
-from aind_metadata_mapper.models import (
-    SessionSettings,
-    JobSettings as GatherMetadataJobSettings,
-)
-from aind_metadata_mapper.bergamo.models import (
-    JobSettings as BergamoSessionJobSettings,
-)
+from aind_data_schema_models.modalities import BehaviorVideos
 
 
 class TestModalityConfigs(unittest.TestCase):
@@ -245,6 +244,20 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
         self.assertEqual(
             configs.metadata_configs.raw_data_description_settings.name,
             configs.s3_prefix,
+        )
+        self.assertEqual(
+            configs.metadata_configs.raw_data_description_settings.modality,
+            [
+                BehaviorVideos(
+                    name="Behavior videos", abbreviation="behavior-videos"
+                )
+            ],
+        )
+        self.assertIsInstance(
+            configs.metadata_configs.procedures_settings, ProceduresSettings
+        )
+        self.assertIsInstance(
+            configs.metadata_configs.subject_settings, SubjectSettings
         )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,6 +17,13 @@ from aind_data_transfer_models.core import (
     ModalityConfigs,
     SubmitJobRequest,
 )
+from aind_metadata_mapper.models import (
+    SessionSettings,
+    JobSettings as GatherMetadataJobSettings,
+)
+from aind_metadata_mapper.bergamo.models import (
+    JobSettings as BergamoSessionJobSettings,
+)
 
 
 class TestModalityConfigs(unittest.TestCase):
@@ -91,7 +98,6 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Set up test class"""
-
         example_configs = BasicUploadJobConfigs(
             project_name="Behavior Platform",
             s3_bucket="some_bucket2",
@@ -104,7 +110,7 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
             ],
             subject_id="123456",
             acq_datetime=datetime(2020, 10, 13, 13, 10, 10),
-            metadata_dir=None,
+            metadata_dir="/some/metadata/dir/",
             metadata_dir_force=False,
             force_cloud_sync=False,
         )
@@ -215,6 +221,32 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
             BasicUploadJobConfigs(platform="MISSING", **base_configs)
         self.assertEqual("Unknown Platform: MISSING", e.exception.args[0])
 
+    def test_fill_in_metadata_configs(self):
+        """Tests that metadata jobSettings are filled in as expected"""
+        metadata_configs = GatherMetadataJobSettings(
+            directory_to_write_to="/some/path/",
+        )
+        base_configs = self.example_configs.model_dump(
+            exclude={
+                "s3_prefix": True,
+                "modalities": {"__all__": {"output_folder_name"}},
+                "metadata_configs": True,
+            }
+        )
+        configs = BasicUploadJobConfigs(
+            metadata_configs=metadata_configs, **base_configs
+        )
+        self.assertEqual(
+            configs.metadata_configs.metadata_dir, configs.metadata_dir
+        )
+        self.assertEqual(
+            configs.metadata_configs.directory_to_write_to, "stage"
+        )
+        self.assertEqual(
+            configs.metadata_configs.raw_data_description_settings.name,
+            configs.s3_prefix,
+        )
+
 
 class TestSubmitJobRequest(unittest.TestCase):
     """Tests SubmitJobRequest class"""
@@ -222,6 +254,7 @@ class TestSubmitJobRequest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Set up example configs to be used in tests"""
+
         example_upload_config = BasicUploadJobConfigs(
             project_name="Behavior Platform",
             s3_bucket="some_bucket2",

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -3,7 +3,7 @@
 import unittest
 from pydantic import ValidationError
 
-from aind_data_schema_models.modalities import ModalityModel, Modality
+from aind_data_schema_models.modalities import Modality, Ecephys, Fib
 from aind_data_transfer_models.trigger import TriggerConfigModel
 
 
@@ -91,8 +91,8 @@ class TestTriggerConfigModel(unittest.TestCase):
             capsule_version="1.0",
             modalities=["ecephys", "fib"],
         )
-        for m in config.modalities:
-            self.assertIsInstance(m, ModalityModel)
+        self.assertIsInstance(config.modalities[0], Ecephys)
+        self.assertIsInstance(config.modalities[1], Fib)
 
         config = TriggerConfigModel(
             job_type="run_generic_pipeline",
@@ -100,8 +100,8 @@ class TestTriggerConfigModel(unittest.TestCase):
             capsule_version="1.0",
             modalities=[Modality.ECEPHYS, Modality.FIB],
         )
-        for m in config.modalities:
-            self.assertIsInstance(m, ModalityModel)
+        self.assertIsInstance(config.modalities[0], Ecephys)
+        self.assertIsInstance(config.modalities[1], Fib)
 
         # emtpy list will set modality to None
         config = TriggerConfigModel(
@@ -122,7 +122,7 @@ class TestTriggerConfigModel(unittest.TestCase):
             )
 
         # wrong modality abbreviation
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(KeyError):
             config = TriggerConfigModel(
                 job_type="run_generic_pipeline",
                 process_capsule_id="0000",


### PR DESCRIPTION
closes #20 

This PR adds an optional field to BasicUploadJobConfigs for GatherMetadataJobConfigs and through a field_validator, fills out some of the basic metadata_configs:
- overwrites directory_to_write_to as "stage"
- fills in metadata_dir (input data)
- Creates subject_settings, procedures_settings, and raw_data_description_settings based on required UploadJob fields
- Unpins aind-data-schema-models 0.3.0