### PR TITLE
fix: trigger configs error

### DIFF
--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -1,5 +1,6 @@
 """Core models for using aind-data-transfer-service"""
 
+import logging
 import re
 from copy import deepcopy
 from datetime import datetime
@@ -332,11 +333,12 @@ class BasicUploadJobConfigs(BaseSettings):
         if (
             self.trigger_capsule_configs is not None
             and self.process_capsule_id is not None
+            and self.trigger_capsule_configs.process_capsule_id
+            != self.process_capsule_id
         ):
-            raise ValueError(
+            logging.warning(
                 "Only one of trigger_capsule_configs or legacy "
-                "process_capsule_id should be set! Please use "
-                "trigger_capsule_configs."
+                "process_capsule_id should be set!"
             )
         if self.trigger_capsule_configs is None:
             default_trigger_capsule_configs = TriggerConfigModel(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ import json
 import unittest
 from datetime import datetime
 from pathlib import Path, PurePosixPath
+from unittest.mock import MagicMock, patch
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
@@ -308,7 +309,10 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
         )
         self.assertEqual(expected_configs, configs.trigger_capsule_configs)
 
-    def test_set_trigger_capsule_configs_user_defined_error(self):
+    @patch("logging.warning")
+    def test_set_trigger_capsule_configs_user_defined_error(
+        self, mock_warn: MagicMock
+    ):
         """Tests set_trigger_capsule_configs values when user defines their
         own settings and an error is raised when user sets both trigger
         configs and process_capsule_id."""
@@ -330,12 +334,15 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
                 "process_capsule_id": True,
             }
         )
-        with self.assertRaises(ValidationError):
-            _ = BasicUploadJobConfigs(
-                trigger_capsule_configs=user_configs,
-                **base_configs,
-                process_capsule_id="def-456",
-            )
+        _ = BasicUploadJobConfigs(
+            trigger_capsule_configs=user_configs,
+            **base_configs,
+            process_capsule_id="def-456",
+        )
+        mock_warn.assert_called_once_with(
+            "Only one of trigger_capsule_configs or legacy "
+            "process_capsule_id should be set!"
+        )
 
     def test_set_trigger_capsule_configs_user_defined_process_id(self):
         """Tests set_trigger_capsule_configs values when user defines their


### PR DESCRIPTION
Closes #40 

- Instead of raising an error if a user sets both the legacy value and current field, will log a warning instead