### PR TITLE
fix: resolves validation errors on computed fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'aind-slurm-rest==0.1.0',
     'aind-data-schema-models>=0.3.2',
     'email-validator',
-    'aind-metadata-mapper==0.18.0'
+    'aind-metadata-mapper==0.18.2'
 ]
 
 [project.optional-dependencies]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,6 +95,37 @@ class TestModalityConfigs(unittest.TestCase):
         self.assertEqual([1, 1], configs.slurm_settings.nodes)
         self.assertEqual(16, configs.slurm_settings.minimum_cpus_per_node)
 
+    def test_round_trip(self):
+        """Tests model can be deserialized easily"""
+
+        configs = ModalityConfigs(modality=Modality.ECEPHYS, source="dir1")
+        model_json = configs.model_dump_json()
+        deserialized_model = ModalityConfigs.model_validate_json(model_json)
+        self.assertEqual(configs, deserialized_model)
+
+    def test_deserialization_fails(self):
+        """Tests deserialization fails when computed field is incorrect"""
+
+        corrupt_json = json.dumps(
+            {
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys",
+                },
+                "source": "dir1",
+                "compress_raw_data": True,
+                "output_folder_name": "incorrect",
+            }
+        )
+        with self.assertRaises(ValidationError) as e:
+            ModalityConfigs.model_validate_json(corrupt_json)
+        errors = json.loads(e.exception.json())
+        expected_msg = (
+            "Value error, output_folder_name incorrect doesn't match ecephys!"
+        )
+        self.assertEqual(1, len(errors))
+        self.assertEqual(expected_msg, errors[0]["msg"])
+
 
 class TestBasicUploadJobConfigs(unittest.TestCase):
     """Tests BasicUploadJobConfigs class"""
@@ -464,6 +495,48 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
             gather_metadata_settings["session_settings"],
             model_json["metadata_configs"]["session_settings"],
         )
+
+    def test_round_trip(self):
+        """Tests model can be serialized and de-serialized easily"""
+        model_json = self.example_configs.model_dump_json()
+        deserialized = BasicUploadJobConfigs.model_validate_json(model_json)
+        self.assertEqual(self.example_configs, deserialized)
+
+    def test_deserialization_fail(self):
+        """Tests deserialization fails with incorrect computed field"""
+        corrupt_json = json.dumps(
+            {
+                "project_name": "Behavior Platform",
+                "s3_bucket": "private",
+                "platform": {
+                    "name": "Behavior platform",
+                    "abbreviation": "behavior",
+                },
+                "modalities": [
+                    {
+                        "modality": {
+                            "name": "Behavior videos",
+                            "abbreviation": "behavior-videos",
+                        },
+                        "source": "dir/data_set_2",
+                        "output_folder_name": "behavior-videos",
+                    }
+                ],
+                "subject_id": "123456",
+                "acq_datetime": "2020-10-13T13:10:10",
+                "metadata_dir": "/some/metadata/dir",
+                "s3_prefix": "incorrect",
+            }
+        )
+        with self.assertRaises(ValidationError) as e:
+            BasicUploadJobConfigs.model_validate_json(corrupt_json)
+        errors = json.loads(e.exception.json())
+        expected_msg = (
+            "Value error, s3_prefix incorrect doesn't match computed "
+            "behavior_123456_2020-10-13_13-10-10!"
+        )
+        self.assertEqual(1, len(errors))
+        self.assertEqual(expected_msg, errors[0]["msg"])
 
 
 class TestSubmitJobRequest(unittest.TestCase):


### PR DESCRIPTION
Closes #44 

- Upgrades to latest aind-metadata-mapper to allow for extra fields in the metadata_configs
- Adds model_validation wrappers to allow computed fields to not raise "extra fields not allowed" validation errors when deserializing from json.