### PR TITLE
feat: allows extra fields in settings

### DIFF
--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -56,6 +56,8 @@ class BucketType(str, Enum):
 class ModalityConfigs(BaseSettings):
     """Class to contain configs for each modality type"""
 
+    model_config = ConfigDict(extra="allow")
+
     # Need some way to extract abbreviations. Maybe a public method can be
     # added to the Modality class
     _MODALITY_MAP: ClassVar = {
@@ -151,7 +153,7 @@ class ModalityConfigs(BaseSettings):
 class BasicUploadJobConfigs(BaseSettings):
     """Configuration for the basic upload job"""
 
-    model_config = ConfigDict(use_enum_values=True)
+    model_config = ConfigDict(use_enum_values=True, extra="allow")
 
     # Need some way to extract abbreviations. Maybe a public method can be
     # added to the Platform class

--- a/src/aind_data_transfer_models/trigger.py
+++ b/src/aind_data_transfer_models/trigger.py
@@ -25,7 +25,7 @@ class ValidJobType(str, Enum):
 class TriggerConfigModel(BaseSettings):
     """Config to be parsed by the AIND Trigger Capsule."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     job_type: ValidJobType = Field(
         description="The type of job to be triggered.",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -126,6 +126,18 @@ class TestModalityConfigs(unittest.TestCase):
         self.assertEqual(1, len(errors))
         self.assertEqual(expected_msg, errors[0]["msg"])
 
+    def test_extra_allow(self):
+        """Tests that extra fields can be passed into model."""
+        config = ModalityConfigs(
+            modality=Modality.ECEPHYS,
+            source="some_dir",
+            extra_field_1="an extra field",
+        )
+        config_json = config.model_dump_json()
+        self.assertEqual(
+            config, ModalityConfigs.model_validate_json(config_json)
+        )
+
 
 class TestBasicUploadJobConfigs(unittest.TestCase):
     """Tests BasicUploadJobConfigs class"""
@@ -676,6 +688,23 @@ class TestSubmitJobRequest(unittest.TestCase):
         self.assertEqual(
             {"begin", "fail"},
             job_settings.upload_jobs[1].email_notification_types,
+        )
+
+    def test_extra_allow(self):
+        """Tests that extra fields can be passed into model."""
+        config = BasicUploadJobConfigs(
+            project_name="some project",
+            platform=Platform.ECEPHYS,
+            modalities=[
+                ModalityConfigs(modality=Modality.ECEPHYS, source="some_dir")
+            ],
+            subject_id="123456",
+            acq_datetime=datetime(2020, 1, 2, 3, 4, 5),
+            extra_field_1="an extra field",
+        )
+        config_json = config.model_dump_json()
+        self.assertEqual(
+            config, BasicUploadJobConfigs.model_validate_json(config_json)
         )
 
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -162,6 +162,21 @@ class TestTriggerConfigModel(unittest.TestCase):
         assert config.input_data_mount == "0000"
         assert config.process_capsule_id == "0101"
 
+    def test_extra_allow(self):
+        """Tests that extra fields can be passed into model."""
+        config = TriggerConfigModel(
+            job_type="ecephys",
+            input_data_point="0000",
+            input_data_mount=None,
+            capsule_id="0101",
+            process_capsule_id=None,
+            extra_field_1="an extra field",
+        )
+        config_json = config.model_dump_json()
+        self.assertEqual(
+            config, TriggerConfigModel.model_validate_json(config_json)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #48 

- Allows extra fields to be passed into models, this will make it easier to add fields without having the service return validation errors while we upgrade the service