### PR TITLE
feat: adds optional extra configs json field

### DIFF
--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -73,13 +73,13 @@ class ModalityConfigs(BaseSettings):
         ),
         title="Extra Configs",
     )
-    extra_configs_dict: Optional[dict] = Field(
+    job_settings: Optional[dict] = Field(
         default=None,
         description=(
             "Configs to pass into modality compression job. Must be json "
             "serializable."
         ),
-        title="Extra Configs Dictionary",
+        title="Job Settings",
     )
     slurm_settings: Optional[V0036JobProperties] = Field(
         default=None,
@@ -148,20 +148,17 @@ class ModalityConfigs(BaseSettings):
 
     @model_validator(mode="after")
     def check_modality_configs(self):
-        """Verifies only one of extra_configs or extra_configs_dict set."""
-        if (
-            self.extra_configs_dict is not None
-            and self.extra_configs is not None
-        ):
+        """Verifies only one of extra_configs or job_settings set."""
+        if self.job_settings is not None and self.extra_configs is not None:
             raise ValueError(
-                "Only extra_configs_dict or extra_configs should be set!"
+                "Only job_settings or extra_configs should be set!"
             )
-        elif self.extra_configs_dict is not None:
+        elif self.job_settings is not None:
             try:
-                json.dumps(self.extra_configs_dict)
+                json.dumps(self.job_settings)
             except Exception as e:
                 raise ValueError(
-                    f"extra_configs_dict must be json serializable! {e}"
+                    f"job_settings must be json serializable! {e}"
                 )
         return self
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -142,19 +142,19 @@ class TestModalityConfigs(unittest.TestCase):
 
     def test_extra_configs_error(self):
         """Tests validation error raised if user sets both extra_configs and
-        extra_configs_dict fields."""
+        job_settings fields."""
 
         with self.assertRaises(ValidationError) as e:
             ModalityConfigs(
                 modality=Modality.ECEPHYS,
                 source="some_dir",
                 extra_configs="some_dir",
-                extra_configs_dict={"param1": 3, "param2": "abc"},
+                job_settings={"param1": 3, "param2": "abc"},
             )
         errors = e.exception.errors()
         self.assertEqual(1, len(errors))
         self.assertEqual(
-            "Value error, Only extra_configs_dict or "
+            "Value error, Only job_settings or "
             "extra_configs should be set!",
             errors[0]["msg"],
         )
@@ -167,10 +167,10 @@ class TestModalityConfigs(unittest.TestCase):
             ModalityConfigs(
                 modality=Modality.ECEPHYS,
                 source="some_dir",
-                extra_configs_dict={"param1": list},
+                job_settings={"param1": list},
             )
         expected_error_message_snippet = (
-            "Value error, extra_configs_dict must be json serializable!"
+            "Value error, job_settings must be json serializable!"
         )
         errors = e.exception.errors()
         self.assertEqual(1, len(errors))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -140,6 +140,42 @@ class TestModalityConfigs(unittest.TestCase):
             config, ModalityConfigs.model_validate_json(config_json)
         )
 
+    def test_extra_configs_error(self):
+        """Tests validation error raised if user sets both extra_configs and
+        extra_configs_dict fields."""
+
+        with self.assertRaises(ValidationError) as e:
+            ModalityConfigs(
+                modality=Modality.ECEPHYS,
+                source="some_dir",
+                extra_configs="some_dir",
+                extra_configs_dict={"param1": 3, "param2": "abc"},
+            )
+        errors = e.exception.errors()
+        self.assertEqual(1, len(errors))
+        self.assertEqual(
+            "Value error, Only extra_configs_dict or "
+            "extra_configs should be set!",
+            errors[0]["msg"],
+        )
+
+    def test_extra_configs_json_error(self):
+        """Tests validation error raised if user sets both extra_configs and
+        extra_configs_dict fields."""
+
+        with self.assertRaises(ValidationError) as e:
+            ModalityConfigs(
+                modality=Modality.ECEPHYS,
+                source="some_dir",
+                extra_configs_dict={"param1": list},
+            )
+        expected_error_message_snippet = (
+            "Value error, extra_configs_dict must be json serializable!"
+        )
+        errors = e.exception.errors()
+        self.assertEqual(1, len(errors))
+        self.assertTrue(expected_error_message_snippet in errors[0]["msg"])
+
 
 class TestBasicUploadJobConfigs(unittest.TestCase):
     """Tests BasicUploadJobConfigs class"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -160,8 +160,8 @@ class TestModalityConfigs(unittest.TestCase):
         )
 
     def test_extra_configs_json_error(self):
-        """Tests validation error raised if user sets both extra_configs and
-        extra_configs_dict fields."""
+        """Tests validation error raised if passes in dictionary that is not
+        json serializable."""
 
         with self.assertRaises(ValidationError) as e:
             ModalityConfigs(


### PR DESCRIPTION
Closes #47 

- Adds optional field so users can attach a json serializable dictionary of parameters to pass into modality compression jobs
- The pydantic "Json" type has some strange behavior when serializing and validating json. Sets the type as an Optional[dict] and validates that the dict can be serialized to json.