### PR TITLE
feat: adds codeocean pipeline monitor configs

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ env.DEFAULT_BRANCH }}
         fetch-depth: 0
         token: ${{ secrets.SERVICE_TOKEN }}
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: | 
         python -m pip install -e .[dev] --no-cache-dir
@@ -66,13 +66,13 @@ jobs:
     needs: tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Pull latest changes
         run: git pull origin main
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           pip install --upgrade setuptools wheel twine build

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'aind-data-schema-models>=0.3.2',
     'email-validator',
     'aind-metadata-mapper==0.18.2',
-    'aind-codeocean-pipeline-monitor>=0.3.0'
+    'aind-codeocean-pipeline-monitor>=0.4.1'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aind-data-transfer-models"
 description = "Generated from aind-library-template"
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     {name = "Allen Institute for Neural Dynamics"}
 ]
@@ -22,7 +22,8 @@ dependencies = [
     'aind-slurm-rest==0.1.0',
     'aind-data-schema-models>=0.3.2',
     'email-validator',
-    'aind-metadata-mapper==0.18.2'
+    'aind-metadata-mapper==0.18.2',
+    'aind-codeocean-pipeline-monitor>=0.3.0'
 ]
 
 [project.optional-dependencies]
@@ -44,7 +45,7 @@ version = {attr = "aind_data_transfer_models.__version__"}
 
 [tool.black]
 line-length = 79
-target_version = ['py38']
+target_version = ['py39']
 exclude = '''
 
 (

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -147,6 +147,14 @@ class CodeOceanPipelineMonitorConfigs(BaseSettings):
 
     model_config = ConfigDict(extra="allow")
 
+    job_type: Optional[str] = Field(
+        default=None,
+        description=(
+            "Legacy field that may be deprecated in the future. Determines "
+            "which default processing pipeline(s) will be run in Code Ocean. "
+            "A list will be made available in the transfer service UI."
+        )
+    )
     pipeline_monitor_capsule_id: Optional[str] = Field(
         default=None,
         description=(

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -153,7 +153,7 @@ class CodeOceanPipelineMonitorConfigs(BaseSettings):
             "Legacy field that may be deprecated in the future. Determines "
             "which default processing pipeline(s) will be run in Code Ocean. "
             "A list will be made available in the transfer service UI."
-        )
+        ),
     )
     pipeline_monitor_capsule_id: Optional[str] = Field(
         default=None,
@@ -185,11 +185,11 @@ class CodeOceanPipelineMonitorConfigs(BaseSettings):
         max_items=10,
     )
     custom_codeocean_metadata: Optional[dict] = Field(
-        default = None,
+        default=None,
         description=(
             "If set to None, defaults will be used. The shape of the "
             "dictionary is strict, but not documented yet."
-        )
+        ),
     )
     raw_data_mount: Optional[str] = Field(
         default=None,

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -5,12 +5,14 @@ import re
 from copy import deepcopy
 from datetime import datetime
 from pathlib import PurePosixPath
-from typing import Any, ClassVar, List, Literal, Optional, Set, Union, get_args
+from typing import Any, ClassVar, List, Literal, Optional, Set, Union, \
+    get_args, Dict
 
 from aind_codeocean_pipeline_monitor.models import PipelineMonitorSettings
 from aind_data_schema_models.data_name_patterns import build_data_name
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
+from aind_data_schema_models.data_name_patterns import DataLevel
 from aind_metadata_mapper.models import (
     JobSettings as GatherMetadataJobSettings,
 )
@@ -176,19 +178,22 @@ class CodeOceanPipelineMonitorConfigs(BaseSettings):
         ),
         max_items=5,
     )
-    additional_raw_data_tags: List[str] = Field(
-        default=[],
+    raw_data_tags: List[str] = Field(
+        default=[DataLevel.RAW.value],
         description=(
-            "Certain tags will be attached to raw data assets registered to "
+            "The data level, subject id, and platform will always be "
+            "attached. Certain tags will be attached to raw data assets "
+            "registered to "
             "Code Ocean. Max 10. Please talk to an admin if more are needed."
         ),
         max_items=10,
     )
-    custom_codeocean_metadata: Optional[dict] = Field(
-        default=None,
+    custom_codeocean_metadata: Optional[Dict[str, str]] = Field(
+        default={"data level": DataLevel.DERIVED.value},
         description=(
-            "If set to None, defaults will be used. The shape of the "
-            "dictionary is strict, but not documented yet."
+            "The fields 'subject id' and 'experiment type' will be attached "
+            "dynamically. The shape of the dictionary is strict, but not"
+            "documented yet."
         ),
     )
     raw_data_mount: Optional[str] = Field(

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -5,14 +5,25 @@ import re
 from copy import deepcopy
 from datetime import datetime
 from pathlib import PurePosixPath
-from typing import Any, ClassVar, List, Literal, Optional, Set, Union, \
-    get_args, Dict
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Union,
+    get_args,
+)
 
 from aind_codeocean_pipeline_monitor.models import PipelineMonitorSettings
-from aind_data_schema_models.data_name_patterns import build_data_name
+from aind_data_schema_models.data_name_patterns import (
+    DataLevel,
+    build_data_name,
+)
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
-from aind_data_schema_models.data_name_patterns import DataLevel
 from aind_metadata_mapper.models import (
     JobSettings as GatherMetadataJobSettings,
 )

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -184,6 +184,13 @@ class CodeOceanPipelineMonitorConfigs(BaseSettings):
         ),
         max_items=10,
     )
+    custom_codeocean_metadata: Optional[dict] = Field(
+        default = None,
+        description=(
+            "If set to None, defaults will be used. The shape of the "
+            "dictionary is strict, but not documented yet."
+        )
+    )
     raw_data_mount: Optional[str] = Field(
         default=None,
         description=(

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import PurePosixPath
 from typing import Any, ClassVar, List, Literal, Optional, Set, Union, get_args
 
+from aind_codeocean_pipeline_monitor.models import PipelineMonitorSettings
 from aind_data_schema_models.data_name_patterns import build_data_name
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
@@ -136,6 +137,53 @@ class ModalityConfigs(BaseSettings):
         return data
 
 
+class CodeOceanPipelineMonitorConfigs(BaseSettings):
+    """
+    Configs for handling registering data to Code Ocean and requesting
+    Code Ocean pipelines to run on the newly registered data. The transfer
+    service will provide defaults, but users can customize these settings if
+    they wish.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    pipeline_monitor_capsule_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "If set to None, then default will be used. If set to an empty "
+            "string, then no request will be sent. If set to a non-empty "
+            "string, will use the user provided value."
+        ),
+    )
+    pipeline_monitor_capsule_settings: Optional[
+        List[PipelineMonitorSettings]
+    ] = Field(
+        default=None,
+        description=(
+            "If set to None, then defaults will be used. If set to an empty "
+            "list, then no request will be sent. If set to a non-empty list, "
+            "will use the user provided values and will not use any defaults. "
+            "A max of 5 pipelines can be requested. Please talk to an admin "
+            "if more are needed."
+        ),
+        max_items=5,
+    )
+    additional_raw_data_tags: List[str] = Field(
+        default=[],
+        description=(
+            "Certain tags will be attached to raw data assets registered to "
+            "Code Ocean. Max 10. Please talk to an admin if more are needed."
+        ),
+        max_items=10,
+    )
+    raw_data_mount: Optional[str] = Field(
+        default=None,
+        description=(
+            "If None, then will set the mount to the data asset name."
+        ),
+    )
+
+
 class BasicUploadJobConfigs(BaseSettings):
     """Configuration for the basic upload job"""
 
@@ -235,11 +283,18 @@ class BasicUploadJobConfigs(BaseSettings):
     trigger_capsule_configs: Optional[TriggerConfigModel] = Field(
         default=None,
         description=(
-            "Settings for the codeocean trigger capsule. "
-            "Validators will set defaults."
+            "(deprecated. Use codeocean_configs) Settings for the codeocean "
+            "trigger capsule. Validators will set defaults."
         ),
-        title="Trigger Capsule Configs",
+        title="Trigger Capsule Configs (deprecated. Use codeocean_configs)",
         validate_default=True,
+    )
+    codeocean_configs: CodeOceanPipelineMonitorConfigs = Field(
+        default=CodeOceanPipelineMonitorConfigs(),
+        description=(
+            "User can pass custom fields. Otherwise, transfer service will "
+            "handle setting default values at runtime."
+        ),
     )
 
     @computed_field

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock, patch
 
+from aind_codeocean_pipeline_monitor.models import PipelineMonitorSettings
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
 from aind_metadata_mapper.models import BergamoSessionJobSettings
@@ -18,10 +19,12 @@ from aind_metadata_mapper.models import (
     SubjectSettings,
 )
 from aind_slurm_rest import V0036JobProperties
+from codeocean.computation import RunParams
 from pydantic import ValidationError
 
 from aind_data_transfer_models.core import (
     BasicUploadJobConfigs,
+    CodeOceanPipelineMonitorConfigs,
     ModalityConfigs,
     SubmitJobRequest,
 )
@@ -139,6 +142,42 @@ class TestModalityConfigs(unittest.TestCase):
         self.assertEqual(
             config, ModalityConfigs.model_validate_json(config_json)
         )
+
+
+class TestCodeOceanPipelineMonitorConfigs(unittest.TestCase):
+    """Tests CodeOceanPipelineMonitorConfigs class"""
+
+    def test_basic_class(self):
+        """Tests basic class serialization round trip"""
+        codeocean_configs = CodeOceanPipelineMonitorConfigs(
+            pipeline_monitor_capsule_settings=[
+                PipelineMonitorSettings(
+                    run_params=RunParams(
+                        pipeline_id="123-abc", parameters=["param1", "param2"]
+                    )
+                )
+            ],
+            additional_raw_data_tags=["custom1", "custom2"],
+            raw_data_mount="custom_mount",
+        )
+        expected_json = {
+            "pipeline_monitor_capsule_settings": [
+                {
+                    "run_params": {
+                        "pipeline_id": "123-abc",
+                        "parameters": ["param1", "param2"],
+                    }
+                }
+            ],
+            "additional_raw_data_tags": ["custom1", "custom2"],
+            "raw_data_mount": "custom_mount",
+        }
+        expected_deser_model = (
+            CodeOceanPipelineMonitorConfigs.model_validate_json(
+                json.dumps(expected_json)
+            )
+        )
+        self.assertEqual(codeocean_configs, expected_deser_model)
 
 
 class TestBasicUploadJobConfigs(unittest.TestCase):
@@ -709,6 +748,34 @@ class TestSubmitJobRequest(unittest.TestCase):
         self.assertEqual(
             config, BasicUploadJobConfigs.model_validate_json(config_json)
         )
+
+    def test_codeocean_configs(self):
+        """Tests user defined codeocean_configs"""
+        codeocean_configs = CodeOceanPipelineMonitorConfigs(
+            pipeline_monitor_capsule_settings=[
+                PipelineMonitorSettings(
+                    run_params=RunParams(
+                        pipeline_id="123-abc", parameters=["param1", "param2"]
+                    )
+                )
+            ],
+            additional_raw_data_tags=["custom1", "custom2"],
+            raw_data_mount="custom_mount",
+        )
+        config = BasicUploadJobConfigs(
+            project_name="some project",
+            platform=Platform.ECEPHYS,
+            modalities=[
+                ModalityConfigs(modality=Modality.ECEPHYS, source="some_dir")
+            ],
+            subject_id="123456",
+            acq_datetime=datetime(2020, 1, 2, 3, 4, 5),
+            codeocean_configs=codeocean_configs,
+        )
+
+        config_json = config.model_dump_json(exclude_none=True)
+        deser_model = BasicUploadJobConfigs.model_validate_json(config_json)
+        self.assertEqual(config, deser_model)
 
 
 if __name__ == "__main__":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -591,6 +591,66 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
         self.assertEqual(1, len(errors))
         self.assertEqual(expected_msg, errors[0]["msg"])
 
+    def test_set_codeocean_configs(self):
+        """Tests that the codeocean defaults are set."""
+        expected_codeocean_configs = {
+            "job_type": "behavior",
+            "pipeline_monitor_capsule_id": None,
+            "pipeline_monitor_capsule_settings": None,
+            "raw_data_tags": ["123456", "behavior", "raw"],
+            "custom_raw_codeocean_metadata": {
+                "data level": "raw",
+                "experiment type": "behavior",
+                "subject id": "123456",
+            },
+            "raw_data_mount": "behavior_123456_2020-10-13_13-10-10",
+        }
+        self.assertEqual(
+            expected_codeocean_configs,
+            json.loads(
+                self.example_configs.codeocean_configs.model_dump_json()
+            ),
+        )
+
+    def test_set_codeocean_configs_override(self):
+        """Tests that the codeocean defaults are set with custom settings."""
+
+        example_configs = BasicUploadJobConfigs(
+            project_name="Behavior Platform",
+            s3_bucket="some_bucket2",
+            platform=Platform.BEHAVIOR,
+            modalities=[
+                ModalityConfigs(
+                    modality=Modality.BEHAVIOR_VIDEOS,
+                    source=(PurePosixPath("dir") / "data_set_2"),
+                ),
+            ],
+            subject_id="123456",
+            acq_datetime=datetime(2020, 10, 13, 13, 10, 10),
+            metadata_dir="/some/metadata/dir/",
+            metadata_dir_force=False,
+            force_cloud_sync=False,
+            codeocean_configs=CodeOceanPipelineMonitorConfigs(
+                raw_data_tags=[], custom_raw_codeocean_metadata=dict()
+            ),
+        )
+
+        expected_codeocean_configs = {
+            "job_type": "behavior",
+            "pipeline_monitor_capsule_id": None,
+            "pipeline_monitor_capsule_settings": None,
+            "raw_data_tags": ["123456", "behavior"],
+            "custom_raw_codeocean_metadata": {
+                "experiment type": "behavior",
+                "subject id": "123456",
+            },
+            "raw_data_mount": "behavior_123456_2020-10-13_13-10-10",
+        }
+        self.assertEqual(
+            expected_codeocean_configs,
+            json.loads(example_configs.codeocean_configs.model_dump_json()),
+        )
+
 
 class TestSubmitJobRequest(unittest.TestCase):
     """Tests SubmitJobRequest class"""


### PR DESCRIPTION
Closes #53

 - Bumps min supported python version to 3.9 because that's the min version supported by the codeocean sdk
 - Adds CodeOceanPipelineMonitor configs