### PR TITLE
feat: adds bool to capture results to default bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## Usage
 
+For more detailed examples, please check out the [readthedocs](https://aind-data-transfer-service.readthedocs.io/en/latest/UserGuide.html#using-the-rest-api).
+
 ## Installation
 - From pypi, run
 ```bash

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -182,6 +182,15 @@ class CodeOceanPipelineMonitorConfigs(BaseSettings):
 
     model_config = ConfigDict(extra="allow")
 
+    capture_results_to_default_bucket: bool = Field(
+        default=True,
+        description=(
+            "If set to True, then the results from each "
+            "pipeline_monitor_capsule_settings pipeline will be captured to a "
+            "default bucket. Set this to False to not modify the capture "
+            "settings."
+        ),
+    )
     job_type: Optional[str] = Field(
         default=None,
         description=(


### PR DESCRIPTION
Closes #58 

- Adds a boolean field that will capture the pipeline results to a default bucket.
  - If set to False, then the pipeline results will be captured as an internal code ocean asset or by what gets set by the user