### PR TITLE
feat: form generation/validation from json schema

### DIFF
--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -93,7 +93,7 @@ class ModalityConfigs(BaseSettings):
         ),
         title="Extra Configs",
     )
-    job_settings: Optional[dict] = Field(
+    job_settings: Optional[Union[dict, str]] = Field(
         default=None,
         description=(
             "Configs to pass into modality compression job. Must be json "
@@ -131,6 +131,19 @@ class ModalityConfigs(BaseSettings):
             return Modality.from_abbreviation(modality_abbreviation)
         else:
             return input_modality
+    
+    @field_validator("job_settings", mode="before")
+    def parse_job_settings_str(
+        cls, job_settings: Optional[Union[dict, str]]
+    ) -> Optional[dict]:
+        """Attempt to convert job_settings to a dict if it is a string"""
+        if isinstance(job_settings, str):
+            try:
+                job_settings_dict = json.loads(job_settings)
+                return job_settings_dict
+            except Exception as e:
+                raise ValueError(f"job_settings must be json serializable! {e}")
+        return job_settings
 
     @field_validator("compress_raw_data", mode="after")
     def get_compress_source_default(

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -376,8 +376,8 @@ class BasicUploadJobConfigs(BaseSettings):
         title="Trigger Capsule Configs (deprecated. Use codeocean_configs)",
         validate_default=True,
     )
-    codeocean_configs: CodeOceanPipelineMonitorConfigs = Field(
-        default=CodeOceanPipelineMonitorConfigs(),
+    codeocean_configs: Optional[CodeOceanPipelineMonitorConfigs] = Field(
+        default=None,
         description=(
             "User can pass custom fields. Otherwise, transfer service will "
             "handle setting default values at runtime."
@@ -670,6 +670,15 @@ class BasicUploadJobConfigs(BaseSettings):
             )
         )
         return validated_self
+
+    @field_validator("codeocean_configs", mode="before")
+    def set_default_codeocean_configs(
+        cls, codeocean_configs: Optional[CodeOceanPipelineMonitorConfigs]
+    ) -> CodeOceanPipelineMonitorConfigs:
+        """Sets default values for codeocean_configs"""
+        if codeocean_configs is None:
+            codeocean_configs = CodeOceanPipelineMonitorConfigs()
+        return codeocean_configs
 
     @model_validator(mode="after")
     def set_codeocean_configs(self):

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -131,7 +131,7 @@ class ModalityConfigs(BaseSettings):
             return Modality.from_abbreviation(modality_abbreviation)
         else:
             return input_modality
-    
+
     @field_validator("job_settings", mode="before")
     def parse_job_settings_str(
         cls, job_settings: Optional[Union[dict, str]]
@@ -142,7 +142,9 @@ class ModalityConfigs(BaseSettings):
                 job_settings_dict = json.loads(job_settings)
                 return job_settings_dict
             except Exception as e:
-                raise ValueError(f"job_settings must be json serializable! {e}")
+                raise ValueError(
+                    f"job_settings must be json serializable! {e}"
+                )
         return job_settings
 
     @field_validator("compress_raw_data", mode="after")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -181,6 +181,28 @@ class TestModalityConfigs(unittest.TestCase):
         self.assertEqual(1, len(errors))
         self.assertTrue(expected_error_message_snippet in errors[0]["msg"])
 
+    def test_job_settings_string(self):
+        """Tests that job_settings can be passed in as a string."""
+
+        configs = ModalityConfigs(
+            modality=Modality.ECEPHYS,
+            source="some_dir",
+            job_settings='{"param1": 3, "param2": "abc"}',
+        )
+        self.assertEqual({"param1": 3, "param2": "abc"}, configs.job_settings)
+        with self.assertRaises(ValidationError) as e:
+            ModalityConfigs(
+                modality=Modality.ECEPHYS,
+                source="some_dir",
+                job_settings="some string",
+            )
+        expected_error_message_snippet = (
+            "Value error, job_settings must be json serializable!"
+        )
+        errors = e.exception.errors()
+        self.assertEqual(1, len(errors))
+        self.assertTrue(expected_error_message_snippet in errors[0]["msg"])
+
 
 class TestCodeOceanPipelineMonitorConfigs(unittest.TestCase):
     """Tests CodeOceanPipelineMonitorConfigs class"""


### PR DESCRIPTION
This PR is to update models for easier form generation/validation from json schema (see https://github.com/AllenNeuralDynamics/aind-data-transfer-service/issues/107).

- `ModalityConfigs`: allow `job_settings` to be str 