### PR TITLE
feat: deprecates metadata_dir_force field

### DIFF
--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -331,13 +331,10 @@ class BasicUploadJobConfigs(BaseSettings):
         description="Directory of metadata",
         title="Metadata Directory",
     )
-    metadata_dir_force: bool = Field(
-        default=False,
-        description=(
-            "Whether to override metadata from service with metadata in "
-            "optional metadata directory"
-        ),
-        title="Metadata Directory Force",
+    metadata_dir_force: Optional[bool] = Field(
+        default=None,
+        description=("Deprecated field. Will be removed in future version."),
+        title="(deprecated) Metadata Directory Force",
     )
     force_cloud_sync: bool = Field(
         default=False,
@@ -586,7 +583,6 @@ class BasicUploadJobConfigs(BaseSettings):
                 project_name=validated_self.project_name,
                 modality=([mod.modality for mod in validated_self.modalities]),
             ),
-            "metadata_dir_force": validated_self.metadata_dir_force,
         }
         # Override user defined values if they were set.
         user_defined_metadata_configs.update(default_metadata_configs)

--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -333,7 +333,7 @@ class BasicUploadJobConfigs(BaseSettings):
     )
     metadata_dir_force: Optional[bool] = Field(
         default=None,
-        description=("Deprecated field. Will be removed in future version."),
+        description="Deprecated field. Will be removed in future version.",
         title="(deprecated) Metadata Directory Force",
     )
     force_cloud_sync: bool = Field(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -263,7 +263,6 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
             subject_id="123456",
             acq_datetime=datetime(2020, 10, 13, 13, 10, 10),
             metadata_dir="/some/metadata/dir/",
-            metadata_dir_force=False,
             force_cloud_sync=False,
         )
         cls.example_configs = example_configs
@@ -539,10 +538,6 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
         self.assertEqual(
             configs.metadata_configs.metadata_dir,
             configs.metadata_dir.as_posix(),
-        )
-        self.assertEqual(
-            configs.metadata_configs.metadata_dir_force,
-            configs.metadata_dir_force,
         )
         self.assertEqual(
             configs.metadata_configs.directory_to_write_to, Path("stage")


### PR DESCRIPTION
Closes #65 

- Adds note that this field is deprecated.
- Will be removed in next major revision.