### PR TITLE
Feat validate project names

### DIFF
--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -286,9 +286,9 @@ class CodeOceanPipelineMonitorConfigs(BaseSettings):
 class BasicUploadJobConfigs(BaseSettings):
     """Configuration for the basic upload job"""
 
+    # noinspection PyMissingConstructor
     def __init__(self, /, **data: Any) -> None:
         """Add context manager to init for validating project_names."""
-        super().__init__(**data)
         self.__pydantic_validator__.validate_python(
             data,
             self_instance=self,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,7 @@ import json
 import unittest
 from datetime import datetime
 from pathlib import Path, PurePosixPath
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from aind_codeocean_pipeline_monitor.models import PipelineMonitorSettings
 from aind_data_schema_models.modalities import Modality
@@ -519,11 +519,10 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
             **base_configs,
             process_capsule_id="def-456",
         )
-        warning_msg = (
-            'Only one of trigger_capsule_configs or legacy '
-            'process_capsule_id should be set!'
+        mock_warn.assert_called_once_with(
+            "Only one of trigger_capsule_configs or legacy "
+            "process_capsule_id should be set!"
         )
-        mock_warn.assert_has_calls([call(warning_msg), call(warning_msg)])
 
     def test_set_trigger_capsule_configs_user_defined_process_id(self):
         """Tests set_trigger_capsule_configs values when user defines their


### PR DESCRIPTION
Closes #68 

- Adds a context manager to validate the BasicUploadJobConfigs project_name against a list of project_names if they are provided
- Allows users to construct a model locally and pushes the project_name validation to a service