### PR TITLE
feat: Update parse_datetime to use ISO

### DIFF
--- a/src/aind_data_transfer_models/core.py
+++ b/src/aind_data_transfer_models/core.py
@@ -472,22 +472,13 @@ class BasicUploadJobConfigs(BaseSettings):
     @field_validator("acq_datetime", mode="before")
     def _parse_datetime(cls, datetime_val: Any) -> datetime:
         """Parses datetime string to %YYYY-%MM-%DD HH:mm:ss"""
-        is_str = isinstance(datetime_val, str)
-        validation_error = ValueError(
-                "Incorrect datetime format, should be"
-                " ISO format (YYYY-MM-DD HH:mm:ss) or MM/DD/YYYY I:MM:SS P"
-            )
-        if is_str and re.match(
+
+        if isinstance(datetime_val, str) and re.match(
             BasicUploadJobConfigs._DATETIME_PATTERN2, datetime_val
         ):
             return datetime.strptime(datetime_val, "%m/%d/%Y %I:%M:%S %p")
-        elif is_str:
-            try:
-                return datetime.fromisoformat(datetime_val)
-            except ValueError:
-                raise validation_error
-        elif is_str:
-            raise validation_error
+        elif isinstance(datetime_val, str):
+            return datetime.fromisoformat(datetime_val.replace("Z", "+00:00"))
         else:
             return datetime_val
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -369,11 +369,29 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
             acq_datetime="2020-05-23T09:05:03Z",
             **self.base_configs,
         )
+        configs4 = BasicUploadJobConfigs(
+            s3_bucket="open",
+            acq_datetime="2020-05-23T09:05:03.266712",
+            **self.base_configs,
+        )
+        configs5 = BasicUploadJobConfigs(
+            s3_bucket="open",
+            acq_datetime="2020-05-23T09:05:03.266712Z",
+            **self.base_configs,
+        )
         self.assertEqual(datetime(2020, 5, 23, 9, 5, 3), configs1.acq_datetime)
         self.assertEqual(datetime(2020, 5, 23, 9, 5, 3), configs2.acq_datetime)
         self.assertEqual(
             datetime(2020, 5, 23, 9, 5, 3, tzinfo=timezone.utc),
             configs3.acq_datetime,
+        )
+        self.assertEqual(
+            datetime(2020, 5, 23, 9, 5, 3, 266712),
+            configs4.acq_datetime,
+        )
+        self.assertEqual(
+            datetime(2020, 5, 23, 9, 5, 3, 266712, tzinfo=timezone.utc),
+            configs5.acq_datetime,
         )
 
     def test_parse_datetime_error(self):
@@ -386,7 +404,7 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
                 **self.base_configs,
             )
         error_msg = json.loads(e.exception.json())[0]["msg"]
-        self.assertTrue("Value error, Incorrect datetime format" in error_msg)
+        self.assertTrue("Value error, Invalid isoformat string" in error_msg)
 
     def test_parse_platform_string(self):
         """Tests platform can be parsed from string"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,7 @@
 
 import json
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock, patch
 
@@ -364,8 +364,17 @@ class TestBasicUploadJobConfigs(unittest.TestCase):
             acq_datetime="05/23/2020 09:05:03 AM",
             **self.base_configs,
         )
+        configs3 = BasicUploadJobConfigs(
+            s3_bucket="open",
+            acq_datetime="2020-05-23T09:05:03Z",
+            **self.base_configs,
+        )
         self.assertEqual(datetime(2020, 5, 23, 9, 5, 3), configs1.acq_datetime)
         self.assertEqual(datetime(2020, 5, 23, 9, 5, 3), configs2.acq_datetime)
+        self.assertEqual(
+            datetime(2020, 5, 23, 9, 5, 3, tzinfo=timezone.utc),
+            configs3.acq_datetime,
+        )
 
     def test_parse_datetime_error(self):
         """Test parse_datetime method raises error"""


### PR DESCRIPTION
There's a regex that is supposed to match ISO format but it's missing a 'Z'. Rather than having to maintain a regex, I changed it so it'd just try datetime.fromisoformat and report if it fails.

Also added a test case that only works for python 3.11. Probably good to have, but it should probably only run for python>3.11.